### PR TITLE
feat: Implement OpenVR driver structure for Virtual Gunstock

### DIFF
--- a/include/PoseUpdateData.h
+++ b/include/PoseUpdateData.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <openvr_driver.h> // For vr::DriverPose_t
+#include <cstdint>         // For uint32_t
+
+struct PoseUpdateData {
+    bool shouldUpdate;
+    uint32_t deviceId; // To identify which tracked device this pose belongs to
+    vr::DriverPose_t pose;
+};

--- a/src/IPCUtils.cpp
+++ b/src/IPCUtils.cpp
@@ -1,0 +1,33 @@
+#include "IPCUtils.h"
+#include <iostream> // For placeholder messages, remove in actual implementation
+
+// Define the global mutex
+std::mutex g_sharedMemoryMutex;
+
+void InitializeIPC() {
+    // TODO: Implement shared memory creation/opening logic
+    // For now, we can just print a message or do nothing.
+    // std::cout << "IPC Initializing..." << std::endl;
+}
+
+void CleanupIPC() {
+    // TODO: Implement shared memory closing/cleanup logic
+    // std::cout << "IPC Cleaning up..." << std::endl;
+}
+
+PoseUpdateData ReadFromSharedMemory() {
+    // TODO: Implement logic to read PoseUpdateData from shared memory
+    // This is a placeholder implementation.
+    // std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
+    // Actual shared memory reading would happen here.
+    return {false, 0, {}}; // Default data indicating no update
+}
+
+void WriteToSharedMemory(const PoseUpdateData& data) {
+    // TODO: Implement logic to write PoseUpdateData to shared memory
+    // This is a placeholder implementation.
+    // std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
+    // Actual shared memory writing would happen here.
+    (void)data; // To suppress unused parameter warning for now.
+    // std::cout << "Writing to shared memory (placeholder)..." << std::endl;
+}

--- a/src/IPCUtils.h
+++ b/src/IPCUtils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <mutex>
+#include "../include/PoseUpdateData.h" // Adjusted path if necessary
+
+// Global mutex for synchronizing access to shared memory
+extern std::mutex g_sharedMemoryMutex;
+
+// Initializes the Inter-Process Communication (IPC) mechanism (e.g., shared memory)
+void InitializeIPC();
+
+// Cleans up the IPC mechanism
+void CleanupIPC();
+
+// Reads the latest pose data from shared memory
+PoseUpdateData ReadFromSharedMemory();
+
+// Writes pose data to shared memory
+void WriteToSharedMemory(const PoseUpdateData& data);

--- a/src/VirtualGunstockDriverProvider.cpp
+++ b/src/VirtualGunstockDriverProvider.cpp
@@ -1,0 +1,63 @@
+#include "VirtualGunstockDriverProvider.h"
+#include "openvr_driver.h" // For VR_INIT_SERVER_DRIVER_CONTEXT, k_InterfaceVersions, DriverPose_t, VRServerDriverHost
+#include <cstdint> // For uint32_t
+#include "IPCUtils.h" // Include for IPC functions
+
+VirtualGunstockDriverProvider g_driverProvider;
+
+vr::EVRInitError VirtualGunstockDriverProvider::Init(vr::IVRDriverContext *pDriverContext)
+{
+    VR_INIT_SERVER_DRIVER_CONTEXT(pDriverContext);
+    InitializeIPC(); // Initialize IPC
+    return vr::VRInitError_None;
+}
+
+void VirtualGunstockDriverProvider::Cleanup()
+{
+    CleanupIPC(); // Cleanup IPC
+}
+
+const char * const *VirtualGunstockDriverProvider::GetInterfaceVersions()
+{
+    return vr::k_InterfaceVersions;
+}
+
+void VirtualGunstockDriverProvider::RunFrame()
+{
+    // --- TODO: Check IPC for a new pose from the UI App ---
+    /*
+    struct PoseUpdateData {
+        bool shouldUpdate;
+        uint32_t deviceId; // Or some other identifier for your tracked device
+        vr::DriverPose_t pose;
+    };
+    */
+
+    // Read the data from shared memory (with proper synchronization like a mutex!)
+    PoseUpdateData data = ReadFromSharedMemory();
+
+    // if (data.shouldUpdate)
+    // {
+    //     // Ensure deviceId is valid and corresponds to a device you've added
+    //     vr::VRServerDriverHost()->TrackedDevicePoseUpdated(data.deviceId, data.pose, sizeof(vr::DriverPose_t));
+    //
+    //     // Reset the flag in shared memory so we don't update again next frame
+    //     // data.shouldUpdate = false;
+    //     WriteToSharedMemory(data); // Write updated data (e.g., shouldUpdate = false)
+    // }
+}
+
+bool VirtualGunstockDriverProvider::ShouldBlockStandbyMode()
+{
+    return false;
+}
+
+void VirtualGunstockDriverProvider::EnterStandby()
+{
+    // Logic for entering standby, if any
+}
+
+void VirtualGunstockDriverProvider::LeaveStandby()
+{
+    // Logic for leaving standby, if any
+}

--- a/src/VirtualGunstockDriverProvider.h
+++ b/src/VirtualGunstockDriverProvider.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "openvr_driver.h"
+
+class VirtualGunstockDriverProvider : public vr::IServerTrackedDeviceProvider
+{
+public:
+    virtual vr::EVRInitError Init(vr::IVRDriverContext *pDriverContext) override;
+    virtual void Cleanup() override;
+    virtual const char * const *GetInterfaceVersions() override;
+    virtual void RunFrame() override;
+    virtual bool ShouldBlockStandbyMode() override;
+    virtual void EnterStandby() override;
+    virtual void LeaveStandby() override;
+};

--- a/src/driver_main.cpp
+++ b/src/driver_main.cpp
@@ -1,49 +1,17 @@
 #include "openvr_driver.h"
+#include "VirtualGunstockDriverProvider.h"
 
-class CExampleServerDriverProvider : public vr::IServerTrackedDeviceProvider
-{
-public:
-    virtual vr::EVRInitError Init(vr::IVRDriverContext *pDriverContext) override
-    {
-        VR_INIT_SERVER_DRIVER_CONTEXT(pDriverContext);
-        return vr::VRInitError_None;
-    }
-    virtual void Cleanup() override {}
-    virtual const char * const *GetInterfaceVersions() override
-    {
-        return vr::k_InterfaceVersions;
-    }
-    virtual void RunFrame() override {}
-    virtual bool ShouldBlockStandbyMode() override { return false; }
-    virtual void EnterStandby() override {}
-    virtual void LeaveStandby() override {}
-};
-
-class CExampleWatchdogDriverProvider : public vr::IVRWatchdogProvider
-{
-public:
-    virtual vr::EVRInitError Init(vr::IVRDriverContext *pDriverContext) override
-    {
-        VR_INIT_WATCHDOG_DRIVER_CONTEXT(pDriverContext);
-        return vr::VRInitError_None;
-    }
-    virtual void Cleanup() override {}
-};
-
-CExampleServerDriverProvider g_serverDriverProvider;
-CExampleWatchdogDriverProvider g_watchdogDriverProvider;
+// Definition moved to VirtualGunstockDriverProvider.h
+extern VirtualGunstockDriverProvider g_driverProvider;
 
 extern "C" __declspec(dllexport)
 void *HmdDriverFactory(const char *pInterfaceName, int *pReturnCode)
 {
     if (0 == strcmp(vr::IServerTrackedDeviceProvider_Version, pInterfaceName))
     {
-        return &g_serverDriverProvider;
+        return &g_driverProvider; // Updated to g_driverProvider
     }
-    if (0 == strcmp(vr::IVRWatchdogProvider_Version, pInterfaceName))
-    {
-        return &g_watchdogDriverProvider;
-    }
+    // Removed watchdog provider section
 
     if (pReturnCode)
         *pReturnCode = vr::VRInitError_Init_InterfaceNotFound;


### PR DESCRIPTION

This commit introduces the foundational structure for the VirtualGunstockDriver, an OpenVR driver designed to override hand poses for a universal virtual gunstock solution.

Key changes include:
- Modified `driver_main.cpp` to use `VirtualGunstockDriverProvider`.
- Created `VirtualGunstockDriverProvider.h` and `VirtualGunstockDriverProvider.cpp` to manage the driver lifecycle and implement core OpenVR provider interfaces (`IServerTrackedDeviceProvider`).
- Implemented `Init`, `Cleanup`, `GetInterfaceVersions`, `RunFrame`, `ShouldBlockStandbyMode`, `EnterStandby`, and `LeaveStandby` methods. The `RunFrame` and `Init`/`Cleanup` methods include placeholders for future IPC (Inter-Process Communication) logic to receive pose updates from a UI application.
- Defined the `PoseUpdateData` struct in `include/PoseUpdateData.h` for data exchange between the UI application and the driver.
- Added placeholder IPC helper functions (`InitializeIPC`, `CleanupIPC`, `ReadFromSharedMemory`, `WriteToSharedMemory`) in `src/IPCUtils.h` and `src/IPCUtils.cpp`.
- Ensured `CMakeLists.txt` correctly incorporates the new files.

The driver is now set up to be recognized by SteamVR. The next steps will involve implementing the shared memory IPC mechanism to allow a separate UI application to send pose data to this driver, which will then use `VRServerDriverHost()->TrackedDevicePoseUpdated()` to override hand poses.