### PR TITLE
I've implemented IPCUtils for shared memory communication.

### DIFF
--- a/src/IPCUtils.cpp
+++ b/src/IPCUtils.cpp
@@ -1,33 +1,92 @@
 #include "IPCUtils.h"
+#include <windows.h>
+#include <string>
 #include <iostream> // For placeholder messages, remove in actual implementation
 
 // Define the global mutex
 std::mutex g_sharedMemoryMutex;
 
+// Global variables for shared memory handles and configuration
+HANDLE hMapFile_ = nullptr;
+LPVOID pBuf_ = nullptr;
+const wchar_t* szName_ = L"PoseUpdateSharedMemory";
+const DWORD dwSize_ = sizeof(PoseUpdateData);
+
 void InitializeIPC() {
-    // TODO: Implement shared memory creation/opening logic
-    // For now, we can just print a message or do nothing.
-    // std::cout << "IPC Initializing..." << std::endl;
+    hMapFile_ = CreateFileMappingW(
+        INVALID_HANDLE_VALUE,    // use paging file
+        NULL,                    // default security
+        PAGE_READWRITE,          // read/write access
+        0,                       // maximum object size (high-order DWORD)
+        dwSize_,                 // maximum object size (low-order DWORD)
+        szName_);                // name of mapping object
+
+    if (hMapFile_ == NULL) {
+        fprintf(stderr, "CreateFileMapping failed with error: %d\n", GetLastError());
+        return;
+    }
+
+    pBuf_ = MapViewOfFile(
+        hMapFile_,   // handle to map object
+        FILE_MAP_ALL_ACCESS, // read/write permission
+        0,
+        0,
+        dwSize_);
+
+    if (pBuf_ == NULL) {
+        fprintf(stderr, "MapViewOfFile failed with error: %d\n", GetLastError());
+        CloseHandle(hMapFile_);
+        return;
+    }
+
+    printf("IPC Initialized successfully. Shared memory created/opened.\n");
 }
 
 void CleanupIPC() {
-    // TODO: Implement shared memory closing/cleanup logic
-    // std::cout << "IPC Cleaning up..." << std::endl;
+    bool errorOccurred = false;
+    if (pBuf_ != nullptr) {
+        if (!UnmapViewOfFile(pBuf_)) {
+            fprintf(stderr, "UnmapViewOfFile failed with error: %d\n", GetLastError());
+            errorOccurred = true;
+        }
+        pBuf_ = nullptr;
+    }
+
+    if (hMapFile_ != nullptr) {
+        if (!CloseHandle(hMapFile_)) {
+            fprintf(stderr, "CloseHandle failed with error: %d\n", GetLastError());
+            errorOccurred = true;
+        }
+        hMapFile_ = nullptr;
+    }
+
+    if (!errorOccurred) {
+        printf("IPC Cleaned up successfully.\n");
+    }
 }
 
 PoseUpdateData ReadFromSharedMemory() {
-    // TODO: Implement logic to read PoseUpdateData from shared memory
-    // This is a placeholder implementation.
-    // std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
-    // Actual shared memory reading would happen here.
-    return {false, 0, {}}; // Default data indicating no update
+    PoseUpdateData data;
+    data.shouldUpdate = false; // Default to no update
+
+    std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
+
+    if (pBuf_ != nullptr) {
+        memcpy(&data, pBuf_, sizeof(PoseUpdateData));
+    } else {
+        fprintf(stderr, "Shared memory not mapped, cannot read.\n");
+        // data.shouldUpdate remains false
+    }
+
+    return data;
 }
 
 void WriteToSharedMemory(const PoseUpdateData& data) {
-    // TODO: Implement logic to write PoseUpdateData to shared memory
-    // This is a placeholder implementation.
-    // std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
-    // Actual shared memory writing would happen here.
-    (void)data; // To suppress unused parameter warning for now.
-    // std::cout << "Writing to shared memory (placeholder)..." << std::endl;
+    std::lock_guard<std::mutex> lock(g_sharedMemoryMutex);
+
+    if (pBuf_ != nullptr) {
+        memcpy(pBuf_, &data, sizeof(PoseUpdateData));
+    } else {
+        fprintf(stderr, "Shared memory not mapped, cannot write.\n");
+    }
 }


### PR DESCRIPTION
This commit provides the full implementation for the IPCUtils methods:
- InitializeIPC: Creates and maps the shared memory segment.
- CleanupIPC: Unmaps and closes the shared memory segment.
- ReadFromSharedMemory: Reads PoseUpdateData from shared memory with mutex protection.
- WriteToSharedMemory: Writes PoseUpdateData to shared memory with mutex protection.

I've also added error handling for Windows API calls and included the necessary headers and global variables for shared memory management.